### PR TITLE
[#3] Add config option: sidebarIcon

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
@@ -19,6 +19,14 @@ public interface DudeWheresMyStuffConfig extends Config {
   }
 
   @ConfigItem(
+      keyName = "sidebarIcon",
+      name = "Sidebar icon",
+      description = "Which icon to display in the RuneLite sidebar")
+  default SidebarIcon sidebarIcon() {
+    return SidebarIcon.DEFAULT;
+  }
+
+  @ConfigItem(
       keyName = "itemSortMode",
       name = "Item Sort Mode",
       description = "Which mode to use when sorting items",

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
@@ -9,7 +9,6 @@ import dev.thource.runelite.dudewheresmystuff.minigames.MinigamesStorageManager;
 import dev.thource.runelite.dudewheresmystuff.playerownedhouse.PlayerOwnedHouseStorageManager;
 import dev.thource.runelite.dudewheresmystuff.stash.StashStorageManager;
 import dev.thource.runelite.dudewheresmystuff.world.WorldStorageManager;
-import java.awt.image.BufferedImage;
 import java.util.Objects;
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
@@ -45,7 +44,6 @@ import net.runelite.client.plugins.itemidentification.ItemIdentificationConfig;
 import net.runelite.client.plugins.itemidentification.ItemIdentificationPlugin;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
-import net.runelite.client.util.ImageUtil;
 
 /**
  * DudeWheresMyStuffPlugin is a RuneLite plugin designed to help accounts of all types find their
@@ -166,15 +164,7 @@ public class DudeWheresMyStuffPlugin extends Plugin {
                         storageManager.getStorages().forEach(Storage::createStoragePanel));
           });
 
-      final BufferedImage icon = ImageUtil.loadImageResource(getClass(), "icon.png");
-
-      navButton =
-          NavigationButton.builder()
-              .tooltip("Dude, Where's My Stuff?")
-              .icon(icon)
-              .panel(panelContainer)
-              .priority(4)
-              .build();
+      navButton = buildNavigationButton();
 
       ItemContainerWatcher.init(client, clientThread, itemManager);
     }
@@ -209,10 +199,25 @@ public class DudeWheresMyStuffPlugin extends Plugin {
 
   @Subscribe
   public void onConfigChanged(ConfigChanged configChanged) {
-    if (Objects.equals(configChanged.getGroup(), DudeWheresMyStuffConfig.CONFIG_GROUP)
-        && Objects.equals(configChanged.getKey(), "showEmptyStorages")) {
-      panelContainer.reorderStoragePanels();
+    if (Objects.equals(configChanged.getGroup(), DudeWheresMyStuffConfig.CONFIG_GROUP)) {
+      if (Objects.equals(configChanged.getKey(), "showEmptyStorages")) {
+        panelContainer.reorderStoragePanels();
+      } else if (Objects.equals(configChanged.getKey(), "sidebarIcon")) {
+        clientToolbar.removeNavigation(navButton);
+
+        navButton = buildNavigationButton();
+        clientToolbar.addNavigation(navButton);
+      }
     }
+  }
+
+  private NavigationButton buildNavigationButton() {
+    return NavigationButton.builder()
+        .tooltip("Dude, Where's My Stuff?")
+        .icon(config.sidebarIcon().getIcon(itemManager))
+        .panel(panelContainer)
+        .priority(4)
+        .build();
   }
 
   @Subscribe

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/SidebarIcon.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/SidebarIcon.java
@@ -1,0 +1,39 @@
+package dev.thource.runelite.dudewheresmystuff;
+
+import java.awt.image.BufferedImage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.ImageUtil;
+
+@Getter
+@RequiredArgsConstructor
+public enum SidebarIcon {
+  DEFAULT(null),
+  DEATH(Tab.DEATH),
+  COINS(Tab.COINS),
+  CARRYABLE_STORAGE(Tab.CARRYABLE_STORAGE),
+  STASH_UNITS(Tab.STASH_UNITS),
+  POH_STORAGE(Tab.POH_STORAGE),
+  WORLD(Tab.WORLD),
+  MINIGAMES(Tab.MINIGAMES);
+
+  private final Tab tab;
+
+  @Override
+  public String toString() {
+    if (tab == null) {
+      return "Default";
+    }
+
+    return tab.getName();
+  }
+
+  public BufferedImage getIcon(ItemManager itemManager) {
+    if (tab == null) {
+      return ImageUtil.loadImageResource(getClass(), "icon.png");
+    }
+
+    return itemManager.getImage(tab.getItemId(), tab.getItemQuantity(), false);
+  }
+}


### PR DESCRIPTION
This adds a new config option "Sidebar icon", which lets you choose what you would like to represent the plugin in the RuneLite sidebar. The choices are "Default" (the plugin icon) or any of the storage tabs (excluding overview and search).