### PR TITLE
Add button to export items to csv

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.9.12'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPanel.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPanel.java
@@ -221,6 +221,7 @@ public class DudeWheresMyStuffPanel extends JPanel {
 
   void setDisplayName(String name) {
     displayName = name;
+    storageManagerManager.setDisplayName(name);
   }
 
   void reset() {

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/ItemStack.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/ItemStack.java
@@ -46,6 +46,7 @@ public class ItemStack {
   @EqualsAndHashCode.Exclude private int haPrice;
   @EqualsAndHashCode.Exclude @Setter private boolean stackable;
   @EqualsAndHashCode.Exclude private ItemIdentification itemIdentification;
+  @EqualsAndHashCode.Exclude private int canonicalId;
 
   /**
    * A constructor.
@@ -89,6 +90,7 @@ public class ItemStack {
         itemStack.isStackable());
 
     this.itemIdentification = itemStack.getItemIdentification();
+    this.canonicalId = itemStack.canonicalId;
   }
 
   // WARNING: ItemStacks created using this constructor will not have an ItemIdentification
@@ -101,6 +103,7 @@ public class ItemStack {
     this.gePrice = gePrice;
     this.haPrice = haPrice;
     this.stackable = stackable;
+    this.canonicalId = id;
   }
 
   /**
@@ -119,7 +122,8 @@ public class ItemStack {
     gePrice = itemManager.getItemPrice(id);
     haPrice = composition.getHaPrice();
     stackable = composition.isStackable();
-    itemIdentification = ItemIdentification.get(itemManager.canonicalize(id));
+    canonicalId = itemManager.canonicalize(id);
+    itemIdentification = ItemIdentification.get(canonicalId);
 
     return true;
   }

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/OverviewTabPanel.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/OverviewTabPanel.java
@@ -32,7 +32,6 @@ import java.awt.event.MouseEvent;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Stream;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JMenu;
@@ -46,7 +45,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemID;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.config.RuneScapeProfile;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.ColorScheme;
 
@@ -61,6 +59,7 @@ class OverviewTabPanel extends TabContentPanel {
       "Are you sure you want to delete ALL of your save data?\nThis cannot be undone.";
   private static final String DELETE_ALL_SAVE_FINAL_WARNING =
       "Are you REALLY sure you want to delete ALL of your save data?\nThis REALLY cannot be undone.";
+  private static final String EXPORT_ITEMS_TEXT = "Export items to CSV";
 
   @Getter private final Map<Tab, OverviewItemPanel> overviews;
   private final OverviewItemPanel summaryOverview;
@@ -274,6 +273,12 @@ class OverviewTabPanel extends TabContentPanel {
                   });
               popupMenu.add(deleteAllData);
             }
+          }
+
+          if (!Objects.equals(pluginPanel.getDisplayName(), "")) {
+            final JMenuItem exportItems = new JMenuItem("Export items to CSV");
+            exportItems.addActionListener(e -> storageManagerManager.exportItems());
+            popupMenu.add(exportItems);
           }
         });
   }

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/Storage.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/Storage.java
@@ -1,12 +1,9 @@
 package dev.thource.runelite.dudewheresmystuff;
 
-import dev.thource.runelite.dudewheresmystuff.death.DeathbankType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
@@ -16,7 +13,6 @@ import javax.swing.border.EmptyBorder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
@@ -121,6 +117,22 @@ public abstract class Storage<T extends StorageType> {
 
   public boolean onMenuOptionClicked(MenuOptionClicked menuOption) {
     return false;
+  }
+
+  /**
+   * Can the items in this storage be withdrawn?
+   *
+   * Should be overridden by subclasses. Should be false for things like minigame points, expired deathbanks,
+   * or deposit-only storages such as balloon log storage.
+   *
+   * NOTE: this abstraction does not work for storages where some items are real and others are not.
+   * For example, the ores in blast furnace storage cannot be withdrawn but bars can. Also, some items
+   * in the POH may be unable to be withdrawn by UIMs without getting the full set.
+   *
+   * @return true if the items are withdrawable, otherwise false
+   */
+  public boolean isWithdrawable() {
+    return true;
   }
 
   /**

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/BottomlessBucket.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/BottomlessBucket.java
@@ -155,4 +155,9 @@ public class BottomlessBucket extends CarryableStorage {
 
     return true;
   }
+
+  @Override
+  public boolean isWithdrawable() {
+    return false;
+  }
 }

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/death/Deathbank.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/death/Deathbank.java
@@ -143,4 +143,10 @@ public class Deathbank extends DeathStorage {
 
     return deathbank;
   }
+
+  @Override
+  public boolean isWithdrawable() {
+    // If the items were lost, then they can't be withdrawn
+    return lostAt == -1;
+  }
 }

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/death/Deathpile.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/death/Deathpile.java
@@ -288,4 +288,8 @@ public class Deathpile extends DeathStorage {
 
     return deathpile;
   }
+  @Override
+  public boolean isWithdrawable() {
+    return !hasExpired();
+  }
 }

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/world/LogStorage.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/world/LogStorage.java
@@ -133,4 +133,9 @@ public class LogStorage extends WorldStorage {
     this.lastUpdated = System.currentTimeMillis();
     return true;
   }
+
+  @Override
+  public boolean isWithdrawable() {
+    return false;
+  }
 }


### PR DESCRIPTION
Screenshot of export button: https://imgur.com/2eZQhFH

File is placed in <runlite dir>/<display name>/dudewheresmystuff-<data>.csv This is based off what the collection log plugin does.

Example CSV output:

ID,Name,Quantity
229,Vial,3
294,Glarial's pebble,1
297,Glarial's urn (empty),1
298,Key,1
299,Mithril seeds,40
303,Small fishing net,1
314,Feather,55
554,Fire rune,99