### PR TITLE
Add deathpile expiry warning

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
@@ -134,7 +134,7 @@ public interface DudeWheresMyStuffConfig extends Config {
   @ConfigItem(
       keyName = "warnDeathpileExpiring",
       name = "Deathpile expiring soon warning",
-      description = "Displays a text warning on sceen when a deathpile is expiring soon.",
+      description = "Displays a text warning on screen when a deathpile is expiring soon.",
       section = deathpileOptionsSection,
       position = 103
   )
@@ -142,7 +142,7 @@ public interface DudeWheresMyStuffConfig extends Config {
 
   @ConfigItem(
       keyName = "warnDeathpileExpiringTime",
-      name = "Deathpile expiring warning time",
+      name = "Deathpile expiry warning time",
       description = "The remaining on your oldest death pile before you start getting alerted.",
       section = deathpileOptionsSection,
       position = 104
@@ -151,8 +151,8 @@ public interface DudeWheresMyStuffConfig extends Config {
 
   @ConfigItem(
       keyName = "warnDeathpileExpiringFontSize",
-      name = "Deathpile expiring font size",
-      description = "Font size for the deathpile expiring warning.",
+      name = "Deathpile expiry font size",
+      description = "Font size for the deathpile expiry warning.",
       section = deathpileOptionsSection,
       position = 105
   )

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
@@ -133,7 +133,7 @@ public interface DudeWheresMyStuffConfig extends Config {
 
   @ConfigItem(
       keyName = "warnDeathpileExpiring",
-      name = "Deathpile expiring soon warning",
+      name = "Deathpile expiry warning",
       description = "Displays a text warning on screen when a deathpile is expiring soon.",
       section = deathpileOptionsSection,
       position = 103

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
@@ -3,6 +3,7 @@ package dev.thource.runelite.dudewheresmystuff;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
 import net.runelite.client.config.Range;
 
@@ -10,6 +11,13 @@ import net.runelite.client.config.Range;
 @SuppressWarnings("SameReturnValue")
 @ConfigGroup("dudewheresmystuff")
 public interface DudeWheresMyStuffConfig extends Config {
+
+  @ConfigSection(
+      name = "Deathpiles Options",
+      description = "Settings deathpiles",
+      position = 100
+  )
+  String deathpileOptionsSection = "Deathpiles Options";
 
   String CONFIG_GROUP = "dudewheresmystuff";
 
@@ -39,25 +47,32 @@ public interface DudeWheresMyStuffConfig extends Config {
           + "enabled, an infobox will be displayed prompting you to swap to the \"Character "
           + "summary\" tab when the plugin doesn't know your play time.<br><br>If the plugin "
           + "doesn't know your play time at the time of your death, the deathpile will default to "
-          + "non cross-client tracking mode.")
+          + "non cross-client tracking mode.",
+      section = deathpileOptionsSection,
+      position = 101
+  )
+
   default boolean deathpilesUseAccountPlayTime() {
     return false;
   }
 
+  @ConfigItem(
+      keyName = "deathpileInfoBox",
+      name = "Show infoboxes for deathpiles",
+      description = "When enabled, infoboxes will be displayed while you have active deathpiles.",
+      section = deathpileOptionsSection,
+      position = 102
+  )
+
+  default boolean deathpileInfoBox() {
+    return true;
+  }
   @ConfigItem(
       keyName = "deathbankInfoBox",
       name = "Show infobox for deathbank",
       description = "When enabled, an infobox will be displayed while you have an active "
           + "deathbank.")
   default boolean deathbankInfoBox() {
-    return true;
-  }
-
-  @ConfigItem(
-      keyName = "deathpileInfoBox",
-      name = "Show infoboxes for deathpiles",
-      description = "When enabled, infoboxes will be displayed while you have active deathpiles.")
-  default boolean deathpileInfoBox() {
     return true;
   }
 
@@ -79,7 +94,10 @@ public interface DudeWheresMyStuffConfig extends Config {
       keyName = "deathpileContingencyMinutes",
       name = "Deathpile contingency (minutes)",
       description = "This amount of minutes is removed from the deathpile timer. If set to 15, any "
-          + "new deathpiles will start with 45 minutes until expiry.")
+          + "new deathpiles will start with 45 minutes until expiry.",
+      section = deathpileOptionsSection,
+      position = 102
+  )
   default int deathpileContingencyMinutes() {
     return 1;
   }
@@ -112,6 +130,33 @@ public interface DudeWheresMyStuffConfig extends Config {
   default ItemSortMode itemSortMode() {
     return ItemSortMode.UNSORTED;
   }
+
+  @ConfigItem(
+      keyName = "warnDeathpileExpiring",
+      name = "Deathpile expiring soon warning",
+      description = "Displays a text warning on sceen when a deathpile is expiring soon.",
+      section = deathpileOptionsSection,
+      position = 103
+  )
+  default boolean warnDeathPileExpiring() {return false;}
+
+  @ConfigItem(
+      keyName = "warnDeathpileExpiringTime",
+      name = "Deathpile expiring warning time",
+      description = "The remaining on your oldest death pile before you start getting alerted.",
+      section = deathpileOptionsSection,
+      position = 104
+  )
+  default int timeUntilDeathpileExpires() {return 5;}
+
+  @ConfigItem(
+      keyName = "warnDeathpileExpiringFontSize",
+      name = "Deathpile expiring font size",
+      description = "Font size for the deathpile expiring warning.",
+      section = deathpileOptionsSection,
+      position = 105
+  )
+  default int warnDeathpileExpiringFontSize() {return 32;}
 
   @ConfigItem(keyName = "itemSortMode", name = "", description = "", hidden = true)
   void setItemSortMode(ItemSortMode itemSortMode);

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffConfig.java
@@ -143,7 +143,7 @@ public interface DudeWheresMyStuffConfig extends Config {
   @ConfigItem(
       keyName = "warnDeathpileExpiringTime",
       name = "Deathpile expiry warning time",
-      description = "The remaining on your oldest death pile before you start getting alerted.",
+      description = "The minutes remaining on your oldest death pile before you start getting alerted.",
       section = deathpileOptionsSection,
       position = 104
   )

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
@@ -450,16 +450,24 @@ public class DudeWheresMyStuffPlugin extends Plugin {
     }
   }
 
-  @Subscribe
-  void onGameTick(GameTick gameTick) {
+  void updateSoonestDeathPileOverlay() {
     Deathpile soonestExpiringDeathpile = deathStorageManager.findSoonestExpiringDeathpile();
 
-    if (soonestExpiringDeathpile != null){
+    if (soonestExpiringDeathpile != null) {
       soonestExpiringDeathpileMessage = deathStorageManager.findSoonestExpiringDeathpileString();
+      // Switches between two overlay colors
       soonestExpiringDeathpileColor = !soonestExpiringDeathpileColor;
-      soonestExpiringDeathpileMinutesLeft = (int) Math.floor((soonestExpiringDeathpile.getExpiryMs() - System.currentTimeMillis()) / 60000f);
+      soonestExpiringDeathpileMinutesLeft = (int) Math.floor(
+          (soonestExpiringDeathpile.getExpiryMs() - System.currentTimeMillis()) / 60_000f);
+    } else {
+      // Reset / clear variables if there's no death pile
+      soonestExpiringDeathpileMessage = null;
+      soonestExpiringDeathpileMinutesLeft = -1;
     }
+  }
 
+  @Subscribe
+  void onGameTick(GameTick gameTick) {
     if (clientState == ClientState.LOGGED_OUT) {
       return;
     }
@@ -502,6 +510,8 @@ public class DudeWheresMyStuffPlugin extends Plugin {
 
       return;
     }
+
+    updateSoonestDeathPileOverlay();
 
     ItemContainerWatcher.onGameTick(this);
     storageManagerManager.onGameTick();

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
@@ -77,7 +77,6 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 )
 @PluginDependency(ItemIdentificationPlugin.class)
 public class DudeWheresMyStuffPlugin extends Plugin {
-
   private static final String CONFIG_KEY_IS_MEMBER = "isMember";
   private static final String CONFIG_KEY_SAVE_MIGRATED = "saveMigrated";
 
@@ -122,10 +121,8 @@ public class DudeWheresMyStuffPlugin extends Plugin {
   private ClientState clientState = ClientState.LOGGED_OUT;
   private boolean pluginStartedAlreadyLoggedIn;
   private String profileKey;
-  public String soonestExpiringDeathpileMessage = null;
-  public int soonestExpiringDeathpileMinutesLeft;
-  public boolean soonestExpiringDeathpileColor = false;
   @Getter private String previewProfileKey;
+  @Getter public Deathpile soonestDeathpile;
 
   /**
    * Displays a confirmation popup to the user and returns true if they confirmed it.
@@ -450,24 +447,9 @@ public class DudeWheresMyStuffPlugin extends Plugin {
     }
   }
 
-  void updateSoonestDeathPileOverlay() {
-    Deathpile soonestExpiringDeathpile = deathStorageManager.findSoonestExpiringDeathpile();
-
-    if (soonestExpiringDeathpile != null) {
-      soonestExpiringDeathpileMessage = deathStorageManager.findSoonestExpiringDeathpileString();
-      // Switches between two overlay colors
-      soonestExpiringDeathpileColor = !soonestExpiringDeathpileColor;
-      soonestExpiringDeathpileMinutesLeft = (int) Math.floor(
-          (soonestExpiringDeathpile.getExpiryMs() - System.currentTimeMillis()) / 60_000f);
-    } else {
-      // Reset / clear variables if there's no death pile
-      soonestExpiringDeathpileMessage = null;
-      soonestExpiringDeathpileMinutesLeft = -1;
-    }
-  }
-
   @Subscribe
   void onGameTick(GameTick gameTick) {
+
     if (clientState == ClientState.LOGGED_OUT) {
       return;
     }
@@ -511,7 +493,8 @@ public class DudeWheresMyStuffPlugin extends Plugin {
       return;
     }
 
-    updateSoonestDeathPileOverlay();
+    soonestDeathpile = deathStorageManager.getSoonestExpiringDeathpile();
+    soonestDeathpileOverlay.updateSoonestDeathpile();
 
     ItemContainerWatcher.onGameTick(this);
     storageManagerManager.onGameTick();

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/death/DeathStorageManager.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/death/DeathStorageManager.java
@@ -229,6 +229,22 @@ public class DeathStorageManager extends StorageManager<DeathStorageType, DeathS
     updateWorldMapPoints();
   }
 
+  public String findSoonestExpiringDeathpileString() {
+    return Optional.ofNullable(getDeathpiles()
+            .filter(deathpile -> !deathpile.hasExpired())
+            .min(Comparator.comparing(Deathpile::getExpiryTime))
+            .orElse(null))
+        .map(Deathpile::getExpireText)
+        .orElse(null);
+  }
+
+  public Deathpile findSoonestExpiringDeathpile() {
+    return getDeathpiles()
+        .filter(deathpile -> !deathpile.hasExpired())
+        .min(Comparator.comparing(Deathpile::getExpiryTime))
+        .orElse(null);
+  }
+
   private boolean checkIfDeathbankWindowIsEmpty() {
     Widget itemWindow = client.getWidget(602, 3);
     // This checks if the item collection window has been emptied while it was open

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/death/DeathStorageManager.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/death/DeathStorageManager.java
@@ -229,19 +229,10 @@ public class DeathStorageManager extends StorageManager<DeathStorageType, DeathS
     updateWorldMapPoints();
   }
 
-  public String findSoonestExpiringDeathpileString() {
-    return Optional.ofNullable(getDeathpiles()
-            .filter(deathpile -> !deathpile.hasExpired())
-            .min(Comparator.comparing(Deathpile::getExpiryTime))
-            .orElse(null))
-        .map(Deathpile::getExpireText)
-        .orElse(null);
-  }
-
-  public Deathpile findSoonestExpiringDeathpile() {
+  public Deathpile getSoonestExpiringDeathpile() {
     return getDeathpiles()
         .filter(deathpile -> !deathpile.hasExpired())
-        .min(Comparator.comparing(Deathpile::getExpiryTime))
+        .min(Comparator.comparing(Deathpile::getExpiryMs))
         .orElse(null);
   }
 

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/death/SoonestDeathpileOverlay.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/death/SoonestDeathpileOverlay.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.components.TitleComponent;
 
 public class SoonestDeathpileOverlay extends Overlay {
 
@@ -33,17 +32,19 @@ public class SoonestDeathpileOverlay extends Overlay {
     return renderText(graphics);
   }
 
-  // If there is a Death pile expiring soon that matchs the config criteria
+  // If there is a Death pile expiring soon that matches the config criteria
   private boolean shouldRenderOverlay() {
     return plugin.soonestExpiringDeathpileMessage != null &&
         plugin.soonestExpiringDeathpileMinutesLeft <= config.timeUntilDeathpileExpires() &&
         config.warnDeathPileExpiring();
   }
 
-  private Dimension renderText (Graphics2D graphics){
-    Font font = FontManager.getRunescapeFont().deriveFont(Font.PLAIN, config.warnDeathpileExpiringFontSize());
+  private Dimension renderText(Graphics2D graphics) {
+    Font font = FontManager.getRunescapeFont()
+        .deriveFont(Font.PLAIN, config.warnDeathpileExpiringFontSize());
     graphics.setFont(font);
-    String deathpileExpiringText = "Your deathpile " + plugin.soonestExpiringDeathpileMessage.toLowerCase();
+    String deathpileExpiringText =
+        "Your deathpile " + plugin.soonestExpiringDeathpileMessage.toLowerCase();
 
     // Alternates between two colors, this could be customized later
     Color textColor = plugin.soonestExpiringDeathpileColor ? Color.RED : Color.WHITE;
@@ -54,7 +55,7 @@ public class SoonestDeathpileOverlay extends Overlay {
     int textWidth = metrics.stringWidth(deathpileExpiringText);
     int textHeight = metrics.getHeight();
 
-    graphics.drawString(deathpileExpiringText,0,0 + textHeight);
+    graphics.drawString(deathpileExpiringText, 0, 0 + textHeight);
 
     return new Dimension(textWidth, textHeight);
   }

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/death/SoonestDeathpileOverlay.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/death/SoonestDeathpileOverlay.java
@@ -1,0 +1,61 @@
+package dev.thource.runelite.dudewheresmystuff.death;
+
+import dev.thource.runelite.dudewheresmystuff.DudeWheresMyStuffConfig;
+import dev.thource.runelite.dudewheresmystuff.DudeWheresMyStuffPlugin;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+public class SoonestDeathpileOverlay extends Overlay {
+
+  @Inject DudeWheresMyStuffPlugin plugin;
+
+  @Inject DudeWheresMyStuffConfig config;
+
+  @Inject
+  public SoonestDeathpileOverlay() {
+    setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
+  }
+
+  @Override
+  public Dimension render(Graphics2D graphics) {
+    if (!shouldRenderOverlay()) {
+      return null;
+    }
+
+    return renderText(graphics);
+  }
+
+  // If there is a Death pile expiring soon that matchs the config criteria
+  private boolean shouldRenderOverlay() {
+    return plugin.soonestExpiringDeathpileMessage != null &&
+        plugin.soonestExpiringDeathpileMinutesLeft <= config.timeUntilDeathpileExpires() &&
+        config.warnDeathPileExpiring();
+  }
+
+  private Dimension renderText (Graphics2D graphics){
+    Font font = FontManager.getRunescapeFont().deriveFont(Font.PLAIN, config.warnDeathpileExpiringFontSize());
+    graphics.setFont(font);
+    String deathpileExpiringText = "Your deathpile " + plugin.soonestExpiringDeathpileMessage.toLowerCase();
+
+    // Alternates between two colors, this could be customized later
+    Color textColor = plugin.soonestExpiringDeathpileColor ? Color.RED : Color.WHITE;
+    graphics.setColor(textColor);
+
+    FontMetrics metrics = graphics.getFontMetrics(font);
+
+    int textWidth = metrics.stringWidth(deathpileExpiringText);
+    int textHeight = metrics.getHeight();
+
+    graphics.drawString(deathpileExpiringText,0,0 + textHeight);
+
+    return new Dimension(textWidth, textHeight);
+  }
+}


### PR DESCRIPTION
Creates a flashing text overlay warning when your oldest death pile is expiring soon
Example: https://streamable.com/dpa986

The purpose of this feature is to make it basically impossible to accidently let your death piles expire when you're AFK-ing or engaged with a quest or something. Obviously a silly mistake, but when you're death piling constantly it's easy to slip up and forget about them. 

I've added options for enabling the warning (off by default), the warning text size, and the amount of time remaining before you start receiving the warning.

I've also grouped deathpile config options in the side panel, since I added a few options.

