### PR TITLE
#223 Add Forestry Kit

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/CarryableStorageManager.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/CarryableStorageManager.java
@@ -29,6 +29,7 @@ public class CarryableStorageManager
     storages.add(new BoltPouch(plugin));
     storages.add(new GnomishFirelighter(plugin));
     storages.add(new MasterScrollBook(plugin));
+    storages.add(new ForestryKit(plugin));
   }
 
   @Override

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/CarryableStorageType.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/CarryableStorageType.java
@@ -33,7 +33,9 @@ public enum CarryableStorageType implements StorageType {
   GNOMISH_FIRELIGHTER("Gnomish Firelighter", -1, false, "gnomishfirelighter", true,
       Collections.singletonList(ItemID.GNOMISH_FIRELIGHTER_20278), -1),
   MASTER_SCROLL_BOOK("Master Scroll Book", -1, true, "masterscrollbook", true, new ArrayList<>(),
-      -1);
+      -1),
+  FORESTRY_KIT("Forestry Kit", 814, false, "forestrykit", true,
+      Arrays.asList(ItemID.FORESTRY_KIT, ItemID.FORESTRY_BASKET, ItemID.OPEN_FORESTRY_BASKET), -1);
 
   private final String name;
   private final int itemContainerId;

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/ForestryKit.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/carryable/ForestryKit.java
@@ -1,0 +1,38 @@
+package dev.thource.runelite.dudewheresmystuff.carryable;
+
+import dev.thource.runelite.dudewheresmystuff.DudeWheresMyStuffPlugin;
+import dev.thource.runelite.dudewheresmystuff.ItemStack;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ItemID;
+
+/**
+ * ForestryKit is responsible for tracking what the player has stored in their Forestry Kit.
+ */
+@Slf4j
+public class ForestryKit extends CarryableStorage {
+
+  ForestryKit(DudeWheresMyStuffPlugin plugin) {
+    super(CarryableStorageType.FORESTRY_KIT, plugin);
+
+    hasStaticItems = true;
+
+    // Basic Forestry Kit storage
+    items.add(new ItemStack(ItemID.ANIMAINFUSED_BARK, plugin));
+    items.add(new ItemStack(ItemID.NATURE_OFFERINGS, plugin));
+    items.add(new ItemStack(ItemID.FORESTERS_RATION, plugin));
+    items.add(new ItemStack(ItemID.SECATEURS_ATTACHMENT, plugin));
+    items.add(new ItemStack(ItemID.LEAVES, plugin));
+    items.add(new ItemStack(ItemID.OAK_LEAVES, plugin));
+    items.add(new ItemStack(ItemID.WILLOW_LEAVES, plugin));
+    items.add(new ItemStack(ItemID.MAPLE_LEAVES, plugin));
+    items.add(new ItemStack(ItemID.YEW_LEAVES, plugin));
+    items.add(new ItemStack(ItemID.MAGIC_LEAVES, plugin));
+    items.add(new ItemStack(ItemID.FORESTRY_TOP, plugin));
+    items.add(new ItemStack(ItemID.FORESTRY_LEGS, plugin));
+    items.add(new ItemStack(ItemID.FORESTRY_HAT, plugin));
+    items.add(new ItemStack(ItemID.FORESTRY_BOOTS, plugin));
+    items.add(new ItemStack(ItemID.WOODCUT_CAPET, plugin));
+
+    // TODO: Forestry Basket Log Storage
+  }
+}


### PR DESCRIPTION
Adds basic support for Forestry Kit. I don't have the Forestry Basket, so I can't check that the container ID is the same for when that is opened.

Items:
- [x] Anima-infused Bark
- [x] Forester's Ration
- [x] Leaves
- [ ] Secateurs Attachment
- [ ] Nature Offerings
- [ ] Forestry set
- [ ] Cape storage attachment (wiki doesn't state, but image of interface shows trimmed cape in list of items)
