### PR TITLE
Update exclusions to avoid dependencies already in runelite

### DIFF
--- a/.idea/saveactions_settings.xml
+++ b/.idea/saveactions_settings.xml
@@ -7,7 +7,6 @@
         <option value="activateOnShortcut" />
         <option value="activateOnBatch" />
         <option value="organizeImports" />
-        <option value="reformat" />
       </set>
     </option>
     <option name="configurationPath" value="" />

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,22 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.20'
 
-    implementation 'com.google.api-client:google-api-client:2.6.0'
-    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.36.0'
-    implementation 'com.google.apis:google-api-services-sheets:v4-rev20240514-2.0.0'
+    implementation('com.google.api-client:google-api-client:2.6.0') {
+        exclude group: 'com.google.oauth-client'
+        exclude group: 'com.google.guava'
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'commons-codec'
+    }
+    implementation('com.google.oauth-client:google-oauth-client-jetty:1.36.0') {
+        exclude group: 'com.google.guava'
+        exclude group: 'org.apache.httpcomponents'
+    }
+    implementation('com.google.apis:google-api-services-sheets:v4-rev20240514-2.0.0') {
+        exclude group: 'com.google.guava'
+        exclude group: 'org.apache.httpcomponents'
+        exclude group: 'commons-logging'
+        exclude group: 'commons-codec'
+    }
 
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
@@ -349,7 +349,10 @@ public class DudeWheresMyStuffPlugin extends Plugin {
         });
         break;
       case "itemSortMode":
-        setItemSortMode(ItemSortMode.valueOf(configChanged.getNewValue()));
+        ItemSortMode newValue = configChanged.getNewValue() != null ?
+            ItemSortMode.valueOf(configChanged.getNewValue()):
+            ItemSortMode.UNSORTED;
+        setItemSortMode(newValue);
         break;
       case "deathpilesUseAccountPlayTime":
       case "deathbankInfoBox":


### PR DESCRIPTION
Adds exclusions for packages already present in runelite/unneeded packages. 

Tested by running the export again. 

Also resolves #160, an NPE related to ItemSortmode