### PR TITLE
Possible fix for the servant's money bag tracking

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/coins/ServantsMoneybag.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/coins/ServantsMoneybag.java
@@ -20,7 +20,7 @@ public class ServantsMoneybag extends CoinsStorage {
     if (widget == null) {
       return false;
     }
-    if (!widget.getText().startsWith("The moneybag ")) {
+    if (!widget.getText().startsWith("The money bag ")) {
       return false;
     }
 


### PR DESCRIPTION
I noticed the string was searching for "moneybag", but the in-game chat text uses "money bag" now - dunno when that changed, but I figured adding the space would fix the tracker too.