### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/D1D5TCSF0)
 
-[![](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/dude-wheres-my-stuff)](https://runelite.net/plugin-hub/show/dude-wheres-my-stuff)
-[![](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/dude-wheres-my-stuff)](https://runelite.net/plugin-hub/show/dude-wheres-my-stuff)
+[![](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/dude-wheres-my-stuff)](https://runelite.net/plugin-hub/show/dude-wheres-my-stuff)
+[![](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/dude-wheres-my-stuff)](https://runelite.net/plugin-hub/show/dude-wheres-my-stuff)
 
 Helps you keep track of your stuff (items, gp, minigame points) in Old School RuneScape by recording
 and showing you where they are in an easy to view way.


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/dude-wheres-my-stuff) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: