### PR TITLE
Include unfinished potions in potion storage

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/world/PotionStorage.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/world/PotionStorage.java
@@ -447,6 +447,13 @@ public class PotionStorage extends WorldStorage {
         continue;
       }
 
+      if (widgetText.startsWith("Quantity:")) {
+        if (currentPotionString != null && currentPotionString.contains("(unf)")) {
+          doseMap.put(currentPotionString, Integer.parseInt(widgetText.replace("Quantity: ", "")));
+        }
+        continue;
+      }
+
       if (widgetText.startsWith("Doses:")) {
         if (currentPotionString != null) {
           doseMap.put(currentPotionString, Integer.parseInt(widgetText.replace("Doses: ", "")));


### PR DESCRIPTION
Currently unfinished potions are not included in potion storage. This adds proper support. 

<img width="1076" height="534" alt="2025-09-23_09-57-31" src="https://github.com/user-attachments/assets/7ad67876-70ff-4447-bad8-373376ca57e5" />
