### PR TITLE
Fix crew banking creating false lost boat entries

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/sailing/ActiveBoatStorage.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/sailing/ActiveBoatStorage.java
@@ -130,7 +130,12 @@ public class ActiveBoatStorage extends BoatStorage {
     // Check if the boat was capsized
     var hpVar = Var.bit(varbitChanged, varbits.hpVarbit);
     if (hpVar.wasChanged() && hpVar.getValue(plugin.getClient()) == 0 && !items.isEmpty()) {
-      plugin.getSailingStorageManager().createLostBoat(this);
+      // Only create a lost boat if actually capsized (port 254).
+      // When crew banks cargo at a dock, HP also goes to 0 but the port remains
+      // set to the dock — not capsized.
+      if (plugin.getClient().getVarbitValue(varbits.portVarbit) == 254) {
+        plugin.getSailingStorageManager().createLostBoat(this);
+      }
       items.clear();
       updateLastUpdated();
       updated = true;


### PR DESCRIPTION
## Summary
- When crew banks cargo at a dock, the boat's HP varbit drops to 0 — the same signal as capsizing — which incorrectly created a "lost boat" entry each time.
- Added a port varbit check: only create a lost boat when `port == 254` (capsized). When crew banks cargo, the port remains set to the dock value.
- Uses `client.getVarbitValue()` (live client state) for the port check since the HP and port varbit change events may fire in any order within the same tick.

## Test plan
- [ ] Capsize a boat with cargo and verify a lost boat entry is created
- [ ] Have crew bank cargo at a dock and verify no lost boat entry is created
- [ ] Verify the cargo hold items are cleared in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)