### PR TITLE
Seed STASH units from Loadout Lab on fresh installs (proposal)

### DIFF
--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
@@ -14,6 +14,7 @@ import dev.thource.runelite.dudewheresmystuff.stash.StashStorageManager;
 import dev.thource.runelite.dudewheresmystuff.world.WorldStorageManager;
 import java.awt.Component;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,6 +98,10 @@ public class DudeWheresMyStuffPlugin extends Plugin {
   private static final String PLUGIN_MESSAGE_KEY_TARGET = "target";
   private static final String PLUGIN_MESSAGE_KEY_VERSION = "version";
   private static final String PLUGIN_MESSAGE_KEY_STORAGES = "storages";
+  private static final String PLUGIN_NAME = "Dude, Where's My Stuff?";
+  private static final String LOADOUT_LAB_NAMESPACE = "loadoutlab";
+  private static final String LOADOUT_LAB_STASH_CATEGORY = "collection";
+  private static final String LOADOUT_LAB_STASH_NAME = "stash";
 
   @Getter @Inject protected PluginManager pluginManager;
   @Getter @Inject protected ItemIdentificationPlugin itemIdentificationPlugin;
@@ -343,6 +348,7 @@ public class DudeWheresMyStuffPlugin extends Plugin {
         () -> {
           storageManagerManager.reset();
           storageManagerManager.load(profileKey);
+          requestLoadoutLabStorages();
           SwingUtilities.invokeLater(panelContainer.getPanel()::softUpdate);
         });
   }
@@ -398,7 +404,7 @@ public class DudeWheresMyStuffPlugin extends Plugin {
 
   private NavigationButton buildNavigationButton() {
     return NavigationButton.builder()
-        .tooltip("Dude, Where's My Stuff?")
+        .tooltip(PLUGIN_NAME)
         .icon(config.sidebarIcon().getIcon(itemManager))
         .panel(panelContainer)
         .priority(4)
@@ -671,9 +677,18 @@ public class DudeWheresMyStuffPlugin extends Plugin {
    */
   @Subscribe
   void onPluginMessage(PluginMessage pluginMessage) {
+    if (pluginMessage.getData() == null) {
+      return;
+    }
+
+    if (Objects.equals(pluginMessage.getNamespace(), LOADOUT_LAB_NAMESPACE)
+        && Objects.equals(pluginMessage.getName(), PLUGIN_MESSAGE_STORAGES_RESPONSE)) {
+      handleLoadoutLabStorages(pluginMessage.getData());
+      return;
+    }
+
     if (!Objects.equals(pluginMessage.getNamespace(), DudeWheresMyStuffConfig.CONFIG_GROUP)
-        || !Objects.equals(pluginMessage.getName(), PLUGIN_MESSAGE_STORAGES_REQUEST)
-        || pluginMessage.getData() == null) {
+        || !Objects.equals(pluginMessage.getName(), PLUGIN_MESSAGE_STORAGES_REQUEST)) {
       return;
     }
 
@@ -685,7 +700,7 @@ public class DudeWheresMyStuffPlugin extends Plugin {
     clientThread.invokeLater(
         () -> {
           Map<String, Object> data = new HashMap<>();
-          data.put(PLUGIN_MESSAGE_KEY_SOURCE, "Dude, Where's My Stuff?");
+          data.put(PLUGIN_MESSAGE_KEY_SOURCE, PLUGIN_NAME);
           data.put(PLUGIN_MESSAGE_KEY_TARGET, requestSource);
           data.put(PLUGIN_MESSAGE_KEY_VERSION, PLUGIN_MESSAGE_VERSION);
           data.put(PLUGIN_MESSAGE_KEY_STORAGES, storageManagerManager.getPluginMessageStorages());
@@ -694,6 +709,78 @@ public class DudeWheresMyStuffPlugin extends Plugin {
               new PluginMessage(
                   DudeWheresMyStuffConfig.CONFIG_GROUP, PLUGIN_MESSAGE_STORAGES_RESPONSE, data));
         });
+  }
+
+  /**
+   * Asks Loadout Lab (if installed) for its tracked storages, so a fresh DWMS install can seed
+   * STASH units the player already recorded there. Fire-and-forget: an absent plugin simply never
+   * replies, and the reply (if any) is handled by {@link #handleLoadoutLabStorages}.
+   */
+  private void requestLoadoutLabStorages() {
+    if (!storageManagerManager.hasUnobservedStash()) {
+      return;
+    }
+
+    Map<String, Object> data = new HashMap<>();
+    data.put(PLUGIN_MESSAGE_KEY_SOURCE, PLUGIN_NAME);
+    eventBus.post(new PluginMessage(LOADOUT_LAB_NAMESPACE, PLUGIN_MESSAGE_STORAGES_REQUEST, data));
+  }
+
+  /**
+   * Consumes a Loadout Lab "storages-response" and seeds never-observed STASH units from the
+   * "stash" collection it reports (see {@link StorageManagerManager#seedStashFromImport}). Only
+   * the STASH category is used; live observations always take precedence.
+   */
+  private void handleLoadoutLabStorages(Map<String, Object> data) {
+    if (!PLUGIN_NAME.equals(data.get(PLUGIN_MESSAGE_KEY_TARGET))
+        || !(data.get(PLUGIN_MESSAGE_KEY_VERSION) instanceof Number)
+        || ((Number) data.get(PLUGIN_MESSAGE_KEY_VERSION)).intValue() != PLUGIN_MESSAGE_VERSION
+        || !(data.get(PLUGIN_MESSAGE_KEY_STORAGES) instanceof List)) {
+      return;
+    }
+
+    Map<Integer, Integer> stashItems = new HashMap<>();
+    for (Object storage : (List<?>) data.get(PLUGIN_MESSAGE_KEY_STORAGES)) {
+      collectLoadoutLabStashItems(storage, stashItems);
+    }
+
+    if (stashItems.isEmpty()) {
+      return;
+    }
+
+    clientThread.invokeLater(
+        () -> {
+          if (storageManagerManager.seedStashFromImport(stashItems)) {
+            SwingUtilities.invokeLater(panelContainer.getPanel()::softUpdate);
+          }
+        });
+  }
+
+  /** Merges one Loadout Lab storage entry into {@code stashItems} if it is the STASH collection. */
+  private void collectLoadoutLabStashItems(Object storage, Map<Integer, Integer> stashItems) {
+    if (!(storage instanceof Map)) {
+      return;
+    }
+
+    Map<?, ?> storageMap = (Map<?, ?>) storage;
+    if (!LOADOUT_LAB_STASH_CATEGORY.equals(storageMap.get("category"))
+        || !LOADOUT_LAB_STASH_NAME.equals(storageMap.get("name"))
+        || !(storageMap.get("items") instanceof List)) {
+      return;
+    }
+
+    for (Object item : (List<?>) storageMap.get("items")) {
+      if (!(item instanceof Map)) {
+        continue;
+      }
+
+      Object id = ((Map<?, ?>) item).get("id");
+      Object quantity = ((Map<?, ?>) item).get("quantity");
+      if (id instanceof Number && quantity instanceof Number) {
+        stashItems.merge(((Number) id).intValue(),
+            (int) Math.min(((Number) quantity).longValue(), Integer.MAX_VALUE), Integer::sum);
+      }
+    }
   }
 
   @Provides

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/DudeWheresMyStuffPlugin.java
@@ -52,10 +52,12 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneScapeProfile;
 import net.runelite.client.config.RuneScapeProfileType;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ClientShutdown;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.ConfigSync;
+import net.runelite.client.events.PluginMessage;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
@@ -87,6 +89,14 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 public class DudeWheresMyStuffPlugin extends Plugin {
 
   private static final String CONFIG_KEY_IS_MEMBER = "isMember";
+  private static final String CONFIG_KEY_VERSION = "version";
+  private static final String PLUGIN_MESSAGE_STORAGES_REQUEST = "storages-request";
+  private static final String PLUGIN_MESSAGE_STORAGES_RESPONSE = "storages-response";
+  private static final int PLUGIN_MESSAGE_VERSION = 1;
+  private static final String PLUGIN_MESSAGE_KEY_SOURCE = "source";
+  private static final String PLUGIN_MESSAGE_KEY_TARGET = "target";
+  private static final String PLUGIN_MESSAGE_KEY_VERSION = "version";
+  private static final String PLUGIN_MESSAGE_KEY_STORAGES = "storages";
 
   @Getter @Inject protected PluginManager pluginManager;
   @Getter @Inject protected ItemIdentificationPlugin itemIdentificationPlugin;
@@ -106,6 +116,7 @@ public class DudeWheresMyStuffPlugin extends Plugin {
   @Inject private OverlayManager overlayManager;
   @Inject private KeyManager keyManager;
   @Getter @Inject private ChatMessageManager chatMessageManager;
+  @Inject private EventBus eventBus;
 
   private ExpiringDeathStorageTilesOverlay expiringDeathStorageTilesOverlay;
   private ExpiringDeathStorageTextOverlay expiringDeathStorageTextOverlay;
@@ -249,8 +260,9 @@ public class DudeWheresMyStuffPlugin extends Plugin {
       clientThread.invoke(() -> navButton = buildNavigationButton());
 
       var lastVersion = configManager.getConfiguration(DudeWheresMyStuffConfig.CONFIG_GROUP,
-          "version");
-      configManager.setConfiguration(DudeWheresMyStuffConfig.CONFIG_GROUP, "version", "2.11.4");
+          CONFIG_KEY_VERSION);
+      configManager.setConfiguration(
+          DudeWheresMyStuffConfig.CONFIG_GROUP, CONFIG_KEY_VERSION, "2.11.4");
       // Delete all lost boats from v2.11.1 and before
       if (lastVersion == null) {
         getProfilesWithData()
@@ -640,6 +652,48 @@ public class DudeWheresMyStuffPlugin extends Plugin {
     }
 
     storageManagerManager.onItemDespawned(itemDespawned);
+  }
+
+  /**
+   * Replies to "storages-request" PluginMessages with a "storages-response" PluginMessage, so
+   * that other plugins can use the tracked storage data of the logged in profile.
+   *
+   * <p>Request: namespace "dudewheresmystuff", name "storages-request", data: "source" (String,
+   * required) - the display name of the requesting plugin. Requests without a source are ignored.
+   *
+   * <p>Response: namespace "dudewheresmystuff", name "storages-response", data: "source" (String,
+   * "Dude, Where's My Stuff?"), "target" (String, the requester's "source", so that requesters
+   * can filter out responses meant for other plugins), "version" (Integer, 1), "storages"
+   * (List&lt;Map&gt;, one per non-empty enabled storage, with keys "category" (String, the
+   * storage manager's config key), "name" (String, the storage's display name), "lastUpdated"
+   * (Long, unix epoch ms, -1 if unknown) and "items" (List&lt;Map&gt; with keys "id" (Integer,
+   * canonical item id) and "quantity" (Long))). The response is posted on the client thread.
+   */
+  @Subscribe
+  void onPluginMessage(PluginMessage pluginMessage) {
+    if (!Objects.equals(pluginMessage.getNamespace(), DudeWheresMyStuffConfig.CONFIG_GROUP)
+        || !Objects.equals(pluginMessage.getName(), PLUGIN_MESSAGE_STORAGES_REQUEST)
+        || pluginMessage.getData() == null) {
+      return;
+    }
+
+    Object requestSource = pluginMessage.getData().get(PLUGIN_MESSAGE_KEY_SOURCE);
+    if (!(requestSource instanceof String) || ((String) requestSource).isEmpty()) {
+      return;
+    }
+
+    clientThread.invokeLater(
+        () -> {
+          Map<String, Object> data = new HashMap<>();
+          data.put(PLUGIN_MESSAGE_KEY_SOURCE, "Dude, Where's My Stuff?");
+          data.put(PLUGIN_MESSAGE_KEY_TARGET, requestSource);
+          data.put(PLUGIN_MESSAGE_KEY_VERSION, PLUGIN_MESSAGE_VERSION);
+          data.put(PLUGIN_MESSAGE_KEY_STORAGES, storageManagerManager.getPluginMessageStorages());
+
+          eventBus.post(
+              new PluginMessage(
+                  DudeWheresMyStuffConfig.CONFIG_GROUP, PLUGIN_MESSAGE_STORAGES_RESPONSE, data));
+        });
   }
 
   @Provides

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/StorageManagerManager.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/StorageManagerManager.java
@@ -18,6 +18,7 @@ import dev.thource.runelite.dudewheresmystuff.export.writers.GoogleSheetsWriter;
 import dev.thource.runelite.dudewheresmystuff.minigames.MinigamesStorageManager;
 import dev.thource.runelite.dudewheresmystuff.playerownedhouse.PlayerOwnedHouseStorageManager;
 import dev.thource.runelite.dudewheresmystuff.sailing.SailingStorageManager;
+import dev.thource.runelite.dudewheresmystuff.stash.StashStorage;
 import dev.thource.runelite.dudewheresmystuff.stash.StashStorageManager;
 import dev.thource.runelite.dudewheresmystuff.world.WorldStorageManager;
 import java.awt.TrayIcon.MessageType;
@@ -305,6 +306,29 @@ public class StorageManagerManager {
       items.add(item);
     }
     return items;
+  }
+
+  /**
+   * Seeds never-observed STASH units from an external owned-item snapshot (see Loadout Lab
+   * import), letting a fresh install recover STASH contents the player already recorded
+   * elsewhere. Live observations always take precedence.
+   *
+   * @return true if any unit was seeded
+   */
+  public boolean seedStashFromImport(Map<Integer, Integer> ownedItems) {
+    boolean seeded = false;
+    for (StashStorage storage : stashStorageManager.getStorages()) {
+      if (storage.seedFromImport(ownedItems)) {
+        seeded = true;
+      }
+    }
+    return seeded;
+  }
+
+  /** True while any enabled STASH unit has never been observed (an import could still help). */
+  public boolean hasUnobservedStash() {
+    return stashStorageManager.getStorages().stream()
+        .anyMatch(storage -> storage.isEnabled() && storage.getLastUpdated() == -1L);
   }
 
   public void onMenuOptionClicked(MenuOptionClicked menuOption) {

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/StorageManagerManager.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/StorageManagerManager.java
@@ -22,8 +22,11 @@ import dev.thource.runelite.dudewheresmystuff.stash.StashStorageManager;
 import dev.thource.runelite.dudewheresmystuff.world.WorldStorageManager;
 import java.awt.TrayIcon.MessageType;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.swing.SwingUtilities;
@@ -41,6 +44,7 @@ import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetClosed;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
 
 /** The manager of storage managers. */
 @Slf4j
@@ -249,6 +253,58 @@ public class StorageManagerManager {
   public List<ItemStack> getItems() {
     return getStorages().filter(Storage::isEnabled).map(Storage::getItems).flatMap(List::stream)
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds the storage data for the "storages-response" PluginMessage: one entry per non-empty
+   * enabled storage (the same set that getStorages() exposes), with the storage manager's config
+   * key as the category and canonical item ids.
+   *
+   * <p>Must be called on the client thread (item ids are canonicalized).
+   *
+   * @return a list of maps, one per storage, with keys "category", "name", "lastUpdated" and
+   *     "items"
+   */
+  public List<Map<String, Object>> getPluginMessageStorages() {
+    var itemManager = plugin.getItemManager();
+    var includedStorages = getStorages().filter(Storage::isEnabled).collect(Collectors.toSet());
+    List<Map<String, Object>> storageData = new ArrayList<>();
+
+    for (StorageManager<?, ?> storageManager : storageManagers) {
+      for (Storage<?> storage : storageManager.getStorages()) {
+        if (!includedStorages.contains(storage)) {
+          continue;
+        }
+
+        List<Map<String, Object>> items = pluginMessageItems(storage, itemManager);
+        if (!items.isEmpty()) {
+          Map<String, Object> storageDatum = new HashMap<>();
+          storageDatum.put("category", storageManager.getConfigKey());
+          storageDatum.put("name", storage.getName());
+          storageDatum.put("lastUpdated", storage.getLastUpdated());
+          storageDatum.put("items", items);
+          storageData.add(storageDatum);
+        }
+      }
+    }
+
+    return storageData;
+  }
+
+  /** The non-empty, canonicalized {@code {id, quantity}} entries of a single storage. */
+  private List<Map<String, Object>> pluginMessageItems(Storage<?> storage, ItemManager itemManager) {
+    List<Map<String, Object>> items = new ArrayList<>();
+    for (ItemStack itemStack : storage.getItems()) {
+      if (itemStack.getId() <= 0 || itemStack.getQuantity() <= 0) {
+        continue;
+      }
+
+      Map<String, Object> item = new HashMap<>();
+      item.put("id", itemManager.canonicalize(itemStack.getId()));
+      item.put("quantity", (long) itemStack.getQuantity());
+      items.add(item);
+    }
+    return items;
   }
 
   public void onMenuOptionClicked(MenuOptionClicked menuOption) {

--- a/src/main/java/dev/thource/runelite/dudewheresmystuff/stash/StashStorage.java
+++ b/src/main/java/dev/thource/runelite/dudewheresmystuff/stash/StashStorage.java
@@ -5,6 +5,7 @@ import dev.thource.runelite.dudewheresmystuff.ItemContainerWatcher;
 import dev.thource.runelite.dudewheresmystuff.ItemStack;
 import dev.thource.runelite.dudewheresmystuff.ItemStorage;
 import dev.thource.runelite.dudewheresmystuff.StorageManager;
+import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import net.runelite.api.ChatMessageType;
@@ -105,6 +106,34 @@ public class StashStorage extends ItemStorage<StashStorageType> {
         }
       }
     }
+  }
+
+  /**
+   * Seeds this unit from an external owned-item snapshot (see Loadout Lab import) when it has
+   * never been observed ({@code lastUpdated == -1}). Adds the unit's default items that the
+   * snapshot reports as owned and stamps {@code lastUpdated}; a no-op once the unit has real data,
+   * so live observations always win and re-imports never clobber them.
+   *
+   * @return true if this unit was seeded
+   */
+  public boolean seedFromImport(Map<Integer, Integer> ownedItems) {
+    if (lastUpdated != -1L || !isEnabled()) {
+      return false;
+    }
+
+    boolean seeded = false;
+    for (int defaultItemId : stashUnit.getDefaultItemIds()) {
+      Integer quantity = ownedItems.get(defaultItemId);
+      if (quantity != null && quantity > 0) {
+        items.add(new ItemStack(defaultItemId, quantity, plugin));
+        seeded = true;
+      }
+    }
+
+    if (seeded) {
+      updateLastUpdated();
+    }
+    return seeded;
   }
 
   @Override


### PR DESCRIPTION
**Draft / proposal — stacked on #435** (the first commit here is that PR's storages contract; review it first). Opening as a draft to discuss the *consume* direction before polishing.

## What

Uses the storages PluginMessage contract in reverse: on login DWMS asks Loadout Lab (`loadoutlab` / `storages-request`) for its tracked storages and **seeds any STASH unit it has never observed** from the `stash` collection LL returns — so a fresh DWMS install can recover STASH contents a player already recorded in Loadout Lab, without re-visiting every unit.

## Why

STASH (and POH costumes) are the storages both plugins observe independently and that require physically visiting to populate. A player who used Loadout Lab first, then installs DWMS, otherwise starts from scratch. This is the onboarding/migration case for the bidirectional contract.

## Safe by construction

- Only seeds units with `lastUpdated == -1` (never observed) — **live observation always wins**, and a seeded unit is never re-seeded. Imports can only fill gaps, never overwrite real data.
- Reversible via the existing per-storage "Reset".
- The request only fires when an unobserved STASH unit exists, so established installs don't ping LL.

## Open design questions (why it's a draft)

- **Provenance:** seeded units currently stamp `lastUpdated = now`, so they persist and display like observed data. Would you rather mark imported data distinctly (a provisional flag / different timestamp)? That's your data model's call.
- **Staleness:** LL's snapshot could be outdated until the unit is re-observed.
- **Scope:** STASH only for now; POH costumes could follow the same shape if you want it.
- **Not yet live-tested** end-to-end (compile-verified, logic guarded). Happy to demo with a sideloaded build.

## Files

- `DudeWheresMyStuffPlugin` — request on load (guarded), the `onPluginMessage` consume branch, `handleLoadoutLabStorages` + parse.
- `StorageManagerManager` — `seedStashFromImport` / `hasUnobservedStash`.
- `StashStorage` — `seedFromImport` (the per-unit seed).
